### PR TITLE
Update babel.js to load babel-runtime

### DIFF
--- a/ext/babel.js
+++ b/ext/babel.js
@@ -10,7 +10,7 @@ export default function (ctx, args, done) {
     block: {
       babel: {
         transform(ctx, args, code, out, done) {
-          const opts = { }
+          const opts = { optional: ["runtime"] }
           if (args && args.indexOf('experimental') !== -1) {
             opts.stage = 0
           }


### PR DESCRIPTION
Using a generator with %%babel gives **ReferenceError: regeneratorRuntime is not defined**

Change the babel builder to use the runtime transformer (which is already in packages.json):

`require("babel").transform("code", { optional: ["runtime"] });`

Loads runtime for ES6 static methods and built-ins and async/generators.